### PR TITLE
Granular settings

### DIFF
--- a/Vostok.Singular.Core.Tests/PathPatternRuleMatcher_Tests.cs
+++ b/Vostok.Singular.Core.Tests/PathPatternRuleMatcher_Tests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using Vostok.Clusterclient.Core.Model;
+using Vostok.Singular.Core.PathPatterns;
+
+namespace Vostok.Singular.Core.Tests
+{
+    [TestFixture]
+    public class PathPatternRuleMatcher_Tests
+    {
+        private List<PathPatternRule> rules;
+        
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            rules = new List<PathPatternRule>
+            {
+                new PathPatternRule
+                {
+                    Method = "*",
+                    PathPattern = new Wildcard("*")
+                }
+            };
+        }
+        
+        [TestCase(RequestMethods.Get, "test/\nasd")]
+        [TestCase(RequestMethods.Get, "test/\n\n\r\n")]
+        [TestCase("SomethingMethod", "\r\nabracadabra")]
+        [TestCase("SomethingMethod", "test/\n/bul'")]
+        public void Should_match_paths_with_special_symbols(string method, string path)
+        {
+            rules.Count(r => PathPatternRuleMatcher.IsMatch(r, method, path)).Should().BeGreaterThan(0);
+        }
+    }
+}

--- a/Vostok.Singular.Core/PathPatterns/Wildcard.cs
+++ b/Vostok.Singular.Core/PathPatterns/Wildcard.cs
@@ -5,7 +5,7 @@ namespace Vostok.Singular.Core.PathPatterns
     internal class Wildcard : Regex
     {
         public Wildcard(string pattern)
-            : base(ConvertPattern(pattern), RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)
+            : base(ConvertPattern(pattern), RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Singleline)
         {
         }
 


### PR DESCRIPTION
Bug fix with '\n' and writing tests for this bug